### PR TITLE
Add debug mode and command config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Container Canary is a tool for recording those requirements as a manifest that c
       - [Environment variables](#environment-variables)
       - [Ports](#ports)
       - [Volumes](#volumes)
+      - [Command](#command)
     - [Checks](#checks)
       - [Exec](#exec)
       - [HTTPGet](#httpget)
@@ -192,6 +193,14 @@ Volumes to be mounted to the container. This is useful if the compute platform w
 ```yaml
 volumes:
   - mountPath: /home/jovyan
+```
+
+#### Command
+
+You can specify a custom command to be run inside the container.
+
+```yaml
+command: foo
 ```
 
 ### Checks

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -56,7 +56,11 @@ var validateCmd = &cobra.Command{
 
 		image := args[0]
 		cmd.Printf("Validating %s against %s\n", image, validatorConfig.Name)
-		v, err := validator.Validate(image, validatorConfig)
+		debug, err := cmd.Flags().GetBool("debug")
+		if err != nil {
+			return err
+		}
+		v, err := validator.Validate(image, validatorConfig, cmd, debug)
 		if err != nil {
 			cmd.Printf("Error: %s\n", err.Error())
 			return errors.New("validation errored")
@@ -90,5 +94,6 @@ func imageArg(cmd *cobra.Command, args []string) error {
 func init() {
 	rootCmd.AddCommand(validateCmd)
 	validateCmd.PersistentFlags().String("file", "", "Path or URL of a manifest to validate against.")
+	validateCmd.PersistentFlags().Bool("debug", false, "Keep container running on failure for debugging.")
 
 }

--- a/internal/apis/v1/types.go
+++ b/internal/apis/v1/types.go
@@ -44,6 +44,10 @@ type Validator struct {
 
 	// A list of volumes to mount on the container.
 	Volumes []Volume
+
+	// A command to run in the container
+	// +optional
+	Command string
 }
 
 type Check struct {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -18,13 +18,35 @@
 package container
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/google/uuid"
 	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
 	v1 "k8s.io/api/core/v1"
 )
+
+type ContainerState struct {
+	Status     string
+	Running    bool
+	Paused     bool
+	Restarting bool
+	OOMKilled  bool
+	Dead       bool
+	Pid        int
+	ExitCode   int
+	Error      string
+	StartedAt  string
+	FinishedAt string
+}
+
+type ContainerInfo struct {
+	Id    string
+	State ContainerState
+}
 
 type Container struct {
 	Name    string
@@ -37,8 +59,9 @@ type Container struct {
 	Volumes []canaryv1.Volume
 }
 
+// Start a container
 func (c Container) Start() error {
-	// Start a container
+
 	commandArgs := []string{"run", "-d"}
 
 	commandArgs = append(commandArgs, "--name", c.Name)
@@ -61,40 +84,78 @@ func (c Container) Start() error {
 
 	commandArgs = append(commandArgs, c.Image)
 
-	id, err := exec.Command(c.Runtime, commandArgs...).Output()
+	if c.Command != "" {
+		commandArgs = append(commandArgs, c.Command)
+	}
+
+	_, err := exec.Command(c.Runtime, commandArgs...).Output()
+
+	for {
+		info, err := c.Status()
+		if err != nil {
+			return err
+		}
+		if info.State.Status == "exited" {
+			return errors.New("container failed to start")
+		}
+		if info.State.Running {
+			break
+		}
+		time.Sleep(time.Second)
+	}
 
 	if err != nil {
 		return err
 	}
 
-	c.Id = string(id)
 	return nil
 }
 
+// Remove a container
 func (c Container) Remove() error {
-	// Remove a container
 	_, err := exec.Command(c.Runtime, "rm", "-f", c.Name).Output()
 	return err
 }
 
-func (c Container) Status() (string, error) {
-	// Get container status
-	_, err := exec.Command(c.Runtime, "inspect", c.Name).Output()
+// Get container status
+func (c Container) Status() (*ContainerInfo, error) {
+
+	output, err := exec.Command(c.Runtime, "inspect", c.Name).Output()
 
 	if err != nil {
-		return "Error", err
+		return nil, err
 	}
-	return "Created", nil
+
+	var info []ContainerInfo
+
+	err = json.Unmarshal(output, &info)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(info) != 1 {
+		return nil, fmt.Errorf("expected 1 container, got %d", len(info))
+	}
+
+	return &info[0], nil
 }
 
+// Exec a command inside a container
 func (c Container) Exec(command ...string) (string, error) {
-	// Exec a command inside a container
+
 	args := append([]string{"exec", c.Name}, command...)
 	out, err := exec.Command(c.Runtime, args...).Output()
 	return string(out), err
 }
 
-func New(image string, env []v1.EnvVar, ports []v1.ServicePort, volumes []canaryv1.Volume) Container {
+// Get container logs
+func (c Container) Logs() (string, error) {
+	out, err := exec.Command(c.Runtime, "logs", c.Name).Output()
+	return string(out), err
+}
+
+func New(image string, env []v1.EnvVar, ports []v1.ServicePort, volumes []canaryv1.Volume, command string) Container {
 	name := fmt.Sprintf("%s%s", "canary-runner-", uuid.New().String()[:8])
-	return Container{Name: name, Image: image, Runtime: "docker", Command: "", Env: env, Ports: ports, Volumes: volumes}
+	return Container{Name: name, Image: image, Runtime: "docker", Command: command, Env: env, Ports: ports, Volumes: volumes}
 }

--- a/internal/container/container_test.go
+++ b/internal/container/container_test.go
@@ -35,7 +35,7 @@ func TestContainer(t *testing.T) {
 	volumes := []canaryv1.Volume{
 		{MountPath: "/foo"},
 	}
-	c := New("nginx", env, ports, volumes)
+	c := New("nginx", env, ports, volumes, "")
 
 	err := c.Start()
 	defer c.Remove()
@@ -57,7 +57,7 @@ func TestContainer(t *testing.T) {
 	}
 }
 func TestContainerRemoves(t *testing.T) {
-	c := New("nginx", nil, nil, nil)
+	c := New("nginx", nil, nil, nil, "")
 
 	err := c.Start()
 	if err != nil {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -72,7 +72,7 @@ func Validate(image string, validator *canaryv1.Validator, cmd *cobra.Command, d
 			allChecksPassed = false
 		}
 	}
-	if debug {
+	if debug && !allChecksPassed {
 		done := make(chan os.Signal, 1)
 		signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 		cmd.Println("Leaving container running for debugging, press ctrl+c to exit...")


### PR DESCRIPTION
Adds a `--debug` flag that leaves the container running after checks have been run to enable debugging. Also added a `command` option to the `Validator` spec to allow custom commands.

Signed-off-by: Jacob Tomlinson <jtomlinson@nvidia.com>