### PR TITLE
Factor Docker container out and change command to slice

### DIFF
--- a/internal/apis/v1/types.go
+++ b/internal/apis/v1/types.go
@@ -47,7 +47,7 @@ type Validator struct {
 
 	// A command to run in the container
 	// +optional
-	Command string
+	Command []string
 }
 
 type Check struct {

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -18,11 +18,7 @@
 package container
 
 import (
-	"encoding/json"
-	"errors"
 	"fmt"
-	"os/exec"
-	"time"
 
 	"github.com/google/uuid"
 	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
@@ -30,132 +26,25 @@ import (
 )
 
 type ContainerState struct {
-	Status     string
-	Running    bool
-	Paused     bool
-	Restarting bool
-	OOMKilled  bool
-	Dead       bool
-	Pid        int
-	ExitCode   int
-	Error      string
-	StartedAt  string
-	FinishedAt string
+	Status  string
+	Running bool
 }
 
 type ContainerInfo struct {
-	Id    string
-	State ContainerState
+	Id         string
+	State      ContainerState
+	RunCommand string
 }
 
-type Container struct {
-	Name    string
-	Id      string
-	Image   string
-	Runtime string
-	Command string
-	Env     []v1.EnvVar
-	Ports   []v1.ServicePort
-	Volumes []canaryv1.Volume
+type ContainerInterface interface {
+	Start() error
+	Remove() error
+	Status() (*ContainerInfo, error)
+	Exec(command ...string) (string, error)
+	Logs() (string, error)
 }
 
-// Start a container
-func (c Container) Start() error {
-
-	commandArgs := []string{"run", "-d"}
-
-	commandArgs = append(commandArgs, "--name", c.Name)
-
-	for _, e := range c.Env {
-		commandArgs = append(commandArgs, "-e", fmt.Sprintf("%s=%s", e.Name, e.Value))
-	}
-
-	for _, p := range c.Ports {
-		commandArgs = append(commandArgs, "-p", fmt.Sprintf("%d:%d/%s", p.Port, p.Port, p.Protocol))
-	}
-
-	for _, v := range c.Volumes {
-		if v.Path != "" {
-			commandArgs = append(commandArgs, "-v", fmt.Sprintf("%s:%s", v.Path, v.MountPath))
-		} else {
-			commandArgs = append(commandArgs, "-v", v.MountPath)
-		}
-	}
-
-	commandArgs = append(commandArgs, c.Image)
-
-	if c.Command != "" {
-		commandArgs = append(commandArgs, c.Command)
-	}
-
-	_, err := exec.Command(c.Runtime, commandArgs...).Output()
-
-	for {
-		info, err := c.Status()
-		if err != nil {
-			return err
-		}
-		if info.State.Status == "exited" {
-			return errors.New("container failed to start")
-		}
-		if info.State.Running {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Remove a container
-func (c Container) Remove() error {
-	_, err := exec.Command(c.Runtime, "rm", "-f", c.Name).Output()
-	return err
-}
-
-// Get container status
-func (c Container) Status() (*ContainerInfo, error) {
-
-	output, err := exec.Command(c.Runtime, "inspect", c.Name).Output()
-
-	if err != nil {
-		return nil, err
-	}
-
-	var info []ContainerInfo
-
-	err = json.Unmarshal(output, &info)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if len(info) != 1 {
-		return nil, fmt.Errorf("expected 1 container, got %d", len(info))
-	}
-
-	return &info[0], nil
-}
-
-// Exec a command inside a container
-func (c Container) Exec(command ...string) (string, error) {
-
-	args := append([]string{"exec", c.Name}, command...)
-	out, err := exec.Command(c.Runtime, args...).Output()
-	return string(out), err
-}
-
-// Get container logs
-func (c Container) Logs() (string, error) {
-	out, err := exec.Command(c.Runtime, "logs", c.Name).Output()
-	return string(out), err
-}
-
-func New(image string, env []v1.EnvVar, ports []v1.ServicePort, volumes []canaryv1.Volume, command string) Container {
+func New(image string, env []v1.EnvVar, ports []v1.ServicePort, volumes []canaryv1.Volume, command []string) ContainerInterface {
 	name := fmt.Sprintf("%s%s", "canary-runner-", uuid.New().String()[:8])
-	return Container{Name: name, Image: image, Runtime: "docker", Command: command, Env: env, Ports: ports, Volumes: volumes}
+	return &DockerContainer{Name: name, Image: image, Command: command, Env: env, Ports: ports, Volumes: volumes}
 }

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -1,0 +1,128 @@
+package container
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+type DockerContainer struct {
+	Name       string
+	Id         string
+	Image      string
+	Command    []string
+	Env        []v1.EnvVar
+	Ports      []v1.ServicePort
+	Volumes    []canaryv1.Volume
+	runCommand string
+}
+
+// Start a container
+func (c *DockerContainer) Start() error {
+
+	commandArgs := []string{"run", "-d"}
+
+	commandArgs = append(commandArgs, "--name", c.Name)
+
+	for _, e := range c.Env {
+		commandArgs = append(commandArgs, "-e", fmt.Sprintf("%s=%s", e.Name, e.Value))
+	}
+
+	for _, p := range c.Ports {
+		commandArgs = append(commandArgs, "-p", fmt.Sprintf("%d:%d/%s", p.Port, p.Port, p.Protocol))
+	}
+
+	for _, v := range c.Volumes {
+		if v.Path != "" {
+			commandArgs = append(commandArgs, "-v", fmt.Sprintf("%s:%s", v.Path, v.MountPath))
+		} else {
+			commandArgs = append(commandArgs, "-v", v.MountPath)
+		}
+	}
+
+	commandArgs = append(commandArgs, c.Image)
+
+	if len(c.Command) > 0 {
+		commandArgs = append(commandArgs, c.Command...)
+	}
+
+	_, err := exec.Command("docker", commandArgs...).Output()
+	c.runCommand = fmt.Sprintf("docker %s", strings.Join(commandArgs, " "))
+
+	for startTime := time.Now(); ; {
+		info, err := c.Status()
+		if err != nil {
+			return err
+		}
+		if info.State.Status == "exited" {
+			return errors.New("container failed to start")
+		}
+		if info.State.Running {
+			break
+		}
+		if time.Since(startTime) > (time.Second * 10) {
+			return errors.New("container failed to start after 10 seconds")
+		}
+		time.Sleep(time.Second)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove a container
+func (c DockerContainer) Remove() error {
+	_, err := exec.Command("docker", "rm", "-f", c.Name).Output()
+	return err
+}
+
+// Get container status
+func (c DockerContainer) Status() (*ContainerInfo, error) {
+
+	output, err := exec.Command("docker", "inspect", c.Name).Output()
+
+	if err != nil {
+		return nil, err
+	}
+
+	var infoList []ContainerInfo
+
+	err = json.Unmarshal(output, &infoList)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(infoList) != 1 {
+		return nil, fmt.Errorf("expected 1 container, got %d", len(infoList))
+	}
+
+	info := infoList[0]
+
+	info.RunCommand = c.runCommand
+
+	return &info, nil
+}
+
+// Exec a command inside a container
+func (c DockerContainer) Exec(command ...string) (string, error) {
+
+	args := append([]string{"exec", c.Name}, command...)
+	out, err := exec.Command("docker", args...).Output()
+	return string(out), err
+}
+
+// Get container logs
+func (c DockerContainer) Logs() (string, error) {
+	out, err := exec.Command("docker", "logs", c.Name).Output()
+	return string(out), err
+}

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -22,10 +22,12 @@ import (
 	"testing"
 
 	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 )
 
-func TestContainer(t *testing.T) {
+func TestDockerContainer(t *testing.T) {
+	assert := assert.New(t)
 	env := []v1.EnvVar{
 		{Name: "FOO", Value: "BAR"},
 	}
@@ -35,7 +37,7 @@ func TestContainer(t *testing.T) {
 	volumes := []canaryv1.Volume{
 		{MountPath: "/foo"},
 	}
-	c := New("nginx", env, ports, volumes, "")
+	c := New("nginx", env, ports, volumes, nil)
 
 	err := c.Start()
 	defer c.Remove()
@@ -43,10 +45,11 @@ func TestContainer(t *testing.T) {
 		t.Errorf("Failed to start container: %s", err.Error())
 	}
 
-	_, err = c.Status()
+	status, err := c.Status()
 	if err != nil {
 		t.Errorf("Failed to inspect container: %s", err.Error())
 	}
+	assert.Contains(status.RunCommand, "docker run", "Run command not stored correctly")
 
 	uname, err := c.Exec("uname", "-a")
 	if err != nil {
@@ -56,8 +59,8 @@ func TestContainer(t *testing.T) {
 		t.Error("Output for command 'uname' did not contain expected string 'Linux'")
 	}
 }
-func TestContainerRemoves(t *testing.T) {
-	c := New("nginx", nil, nil, nil, "")
+func TestDockerContainerRemoves(t *testing.T) {
+	c := New("nginx", nil, nil, nil, nil)
 
 	err := c.Start()
 	if err != nil {

--- a/internal/validator/exec.go
+++ b/internal/validator/exec.go
@@ -22,7 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func ExecCheck(c *container.Container, action *v1.ExecAction) (bool, error) {
+func ExecCheck(c container.ContainerInterface, action *v1.ExecAction) (bool, error) {
 	_, err := c.Exec(action.Command...)
 	if err != nil {
 		return false, nil

--- a/internal/validator/httpget.go
+++ b/internal/validator/httpget.go
@@ -26,7 +26,7 @@ import (
 	"github.com/nvidia/container-canary/internal/container"
 )
 
-func HTTPGetCheck(c *container.Container, action *canaryv1.HTTPGetAction) (bool, error) {
+func HTTPGetCheck(c container.ContainerInterface, action *canaryv1.HTTPGetAction) (bool, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d%s", action.Port, action.Path), nil)
 	if err != nil {


### PR DESCRIPTION
- Factor `DockerContainer` out of `Container` and introduce `ContainerInterface`.
- Switch `Validator.Command` to a `[]string` instead for easy passing to `exec`.
- Store the command used to start the container and include it in the `ContainerStatus`.
- Add more verbose debugging output.