### PR TITLE
Implement check retry thresholds and interval

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,9 @@ test: ## Run tests
 version:
 	@echo version: $(VERSION)
 
-clean: ## Remove previous builds
+clean: ## Remove previous builds and clear test cache
 	rm -f bin/$(EXECUTABLE)*
+	go clean -testcache
 
 help: ## Display available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/examples/binder.yaml
+++ b/examples/binder.yaml
@@ -52,4 +52,4 @@ checks:
       httpGet:
         path: /
         port: 8888
-      initialDelaySeconds: 10
+      failureThreshold: 30

--- a/examples/kubeflow.yaml
+++ b/examples/kubeflow.yaml
@@ -42,14 +42,14 @@ checks:
       httpGet:
         path: /
         port: 8888
-      initialDelaySeconds: 10
+      failureThreshold: 30
   - name: NB_PREFIX
     description: 🧭 Correctly routes the NB_PREFIX
     probe:
       httpGet:
         path: /hub/jovyan/lab
         port: 8888
-      initialDelaySeconds: 10
+      failureThreshold: 30
   - name: allow-origin-all
     description: "🔓 Sets 'Access-Control-Allow-Origin: *' header"
     probe:
@@ -59,4 +59,4 @@ checks:
         responseHttpHeaders:
           - name: Access-Control-Allow-Origin
             value: "*"
-      initialDelaySeconds: 10
+      failureThreshold: 30

--- a/internal/validator/exec.go
+++ b/internal/validator/exec.go
@@ -18,11 +18,12 @@
 package validator
 
 import (
+	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
 	"github.com/nvidia/container-canary/internal/container"
-	v1 "k8s.io/api/core/v1"
 )
 
-func ExecCheck(c container.ContainerInterface, action *v1.ExecAction) (bool, error) {
+func ExecCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, error) {
+	action := probe.Exec
 	_, err := c.Exec(action.Command...)
 	if err != nil {
 		return false, nil

--- a/internal/validator/httpget.go
+++ b/internal/validator/httpget.go
@@ -26,7 +26,8 @@ import (
 	"github.com/nvidia/container-canary/internal/container"
 )
 
-func HTTPGetCheck(c container.ContainerInterface, action *canaryv1.HTTPGetAction) (bool, error) {
+func HTTPGetCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, error) {
+	action := probe.HTTPGet
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d%s", action.Port, action.Path), nil)
 	if err != nil {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -97,7 +97,7 @@ func runCheck(results chan<- checkResult, c container.ContainerInterface, check 
 		results <- checkResult{false, fmt.Errorf("check '%s' has no known probes", check.Name)}
 		return
 	}
-	results <- checkResult{p, nil}
+	results <- checkResult{p, err}
 	terminal.PrintCheckItem("", check.Description, getStatus(p, err))
 }
 

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -86,20 +86,47 @@ func Validate(image string, validator *canaryv1.Validator, cmd *cobra.Command, d
 }
 
 func runCheck(results chan<- checkResult, c container.ContainerInterface, check canaryv1.Check) {
-	// TODO Retry each check on fail "failureThreshold" times with "periodSeconds" sleep between
-	// TODO Retry each check on success "successThreshold" times with "periodSeconds" sleep between
-	time.Sleep(time.Duration(check.Probe.InitialDelaySeconds) * time.Second)
+	var p bool
+	var err error
+	// TODO Make more SOLID (O)
 	if check.Probe.Exec != nil {
-		p, err := ExecCheck(c, check.Probe.Exec)
-		results <- checkResult{p, nil}
-		terminal.PrintCheckItem("", check.Description, getStatus(p, err))
+		p, err = executeCheck(ExecCheck, c, &check.Probe)
+	} else if check.Probe.HTTPGet != nil {
+		p, err = executeCheck(HTTPGetCheck, c, &check.Probe)
+	} else {
+		results <- checkResult{false, fmt.Errorf("check '%s' has no known probes", check.Name)}
 		return
 	}
-	if check.Probe.HTTPGet != nil {
-		p, err := HTTPGetCheck(c, check.Probe.HTTPGet)
-		results <- checkResult{p, nil}
-		terminal.PrintCheckItem("", check.Description, getStatus(p, err))
-		return
+	results <- checkResult{p, nil}
+	terminal.PrintCheckItem("", check.Description, getStatus(p, err))
+}
+
+type probeCallable func(container.ContainerInterface, *canaryv1.Probe) (bool, error)
+
+// Run a check method with appropriate delay, retries and retry interval
+func executeCheck(method probeCallable, c container.ContainerInterface, probe *canaryv1.Probe) (bool, error) {
+	time.Sleep(time.Duration(probe.InitialDelaySeconds) * time.Second)
+	passes := 0
+	fails := 0
+	start := time.Now()
+	for {
+		passFail, err := method(c, probe)
+		if err != nil {
+			return false, err
+		}
+		if passFail {
+			passes += 1
+			fails = 0
+		} else {
+			fails += 1
+			passes = 0
+		}
+		if passes >= probe.SuccessThreshold || fails >= probe.FailureThreshold {
+			return passFail, err
+		}
+		if time.Since(start) > time.Duration(probe.TimeoutSeconds)*time.Second {
+			return false, fmt.Errorf("check timed out after %d seconds", probe.TimeoutSeconds)
+		}
+		time.Sleep(time.Duration(probe.PeriodSeconds) * time.Second)
 	}
-	results <- checkResult{false, fmt.Errorf("check '%s' has no known probes", check.Name)}
 }


### PR DESCRIPTION
This PR factors the execution of the individual checks out into a dispatcher. This allowed cleaner implementation of the retry mechanisms. The configurable timeout, delay, thresholds and interval have now been implemented.

```yaml
checks:
  - name: uid
    description: User ID is 1234
    probe:
      exec:
        command: [...]
      initialDelaySeconds: 0  # Delay after starting the container before the check should be run
      timeoutSeconds: 30  # Overall timeout for the check
      successThreshold: 1  # Number of times the check must pass before moving on
      failureThreshold: 1  # Number of times the check is allowed to fail before giving up
      periodSeconds: 1  # Interval between runs if threasholds are >1
```

One benefit is that now instead of having a flaky 10 second delay to wait for the container to start for the validation examples we can set the failure threshold to some high number and have the check retry every second. This resulted in the test suite going from 14 seconds to 4 seconds.