### PR TITLE
Add TCP probe and fix default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Container Canary is a tool for recording those requirements as a manifest that c
     - [Checks](#checks)
       - [Exec](#exec)
       - [HTTPGet](#httpget)
+      - [TCPSocket](#tcpsocket)
       - [Delays, timeouts, periods and thresholds](#delays-timeouts-periods-and-thresholds)
   - [Contributing](#contributing)
   - [Maintaining](#maintaining)
@@ -251,6 +252,19 @@ checks:
         responseHttpHeaders:  # Optional, headers that you expect to see in the response
           - name: Access-Control-Allow-Origin
             value: "*"
+```
+
+#### TCPSocket
+
+A TCP Socket check will ensure something is listening on a specific TCP port.
+
+```yaml
+checks:
+  - name: tcp
+    description: Is listening via TCP on port 80
+    probe:
+      tcpSocket:
+        port: 80
 ```
 
 #### Delays, timeouts, periods and thresholds

--- a/examples/dask-scheduler.yaml
+++ b/examples/dask-scheduler.yaml
@@ -1,0 +1,26 @@
+apiVersion: container-canary.nvidia.com/v1
+kind: Validator
+name: dask-scheduler
+description: Dask Scheduler
+documentation:
+command:
+  - dask-scheduler
+ports:
+  - port: 8786
+    protocol: TCP
+  - port: 8787
+    protocol: TCP
+checks:
+  - name: dashboard
+    description: 🌏 Exposes the Dashboard on port 8787
+    probe:
+      httpGet:
+        path: /
+        port: 8787
+      failureThreshold: 30
+  - name: comm
+    description: ⛓ Exposes Dask comm on port 8786
+    probe:
+      tcpSocket:
+        port: 8786
+      failureThreshold: 30

--- a/internal/apis/v1/types.go
+++ b/internal/apis/v1/types.go
@@ -74,11 +74,31 @@ type Probe struct {
 
 	FailureThreshold int `yaml:"failureThreshold"`
 
-	TerminationGracePeriodSeconds *int `yaml:"terminationGracePeriodSeconds"`
+	TerminationGracePeriodSeconds int `yaml:"terminationGracePeriodSeconds"`
 
 	Exec *v1.ExecAction `yaml:"exec"`
 
 	HTTPGet *HTTPGetAction `yaml:"httpGet"`
+
+	TCPSocket *TCPSocketAction `yaml:"tcpSocket" `
+}
+
+func (p *Probe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawProbe Probe
+	raw := rawProbe{
+		InitialDelaySeconds:           0,
+		TimeoutSeconds:                30,
+		PeriodSeconds:                 1,
+		SuccessThreshold:              1,
+		FailureThreshold:              1,
+		TerminationGracePeriodSeconds: 30,
+	}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+
+	*p = Probe(raw)
+	return nil
 }
 
 type HTTPGetAction struct {
@@ -88,10 +108,6 @@ type HTTPGetAction struct {
 	// Number of the port to access on the container.
 	// Number must be in the range 1 to 65535.
 	Port int `json:"port"`
-	// Host name to connect to, defaults to the pod IP. You probably want to set
-	// "Host" in httpHeaders instead.
-	// +optional
-	Host string `json:"host,omitempty"`
 	// Scheme to use for connecting to the host.
 	// Defaults to HTTP.
 	// +optional
@@ -102,6 +118,12 @@ type HTTPGetAction struct {
 	// Headers expected in the response. Check will fail if any are missing.
 	// +optional
 	ResponseHTTPHeaders []v1.HTTPHeader `json:"responseHttpHeaders,omitempty"`
+}
+
+type TCPSocketAction struct {
+	// Number or name of the port to access on the container.
+	// Number must be in the range 1 to 65535.
+	Port int `json:"port"`
 }
 
 type Volume struct {

--- a/internal/validator/httpget.go
+++ b/internal/validator/httpget.go
@@ -31,7 +31,6 @@ func HTTPGetCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, 
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d%s", action.Port, action.Path), nil)
 	if err != nil {
-		// fmt.Println(err.Error())
 		return false, nil
 	}
 	req.Close = true
@@ -41,7 +40,6 @@ func HTTPGetCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, 
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		// fmt.Println(err.Error())
 		return false, nil
 	}
 	for _, header := range action.ResponseHTTPHeaders {

--- a/internal/validator/tcp.go
+++ b/internal/validator/tcp.go
@@ -19,38 +19,18 @@ package validator
 
 import (
 	"fmt"
-	"net/http"
-	"strings"
+	"net"
 
 	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
 	"github.com/nvidia/container-canary/internal/container"
 )
 
-func HTTPGetCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, error) {
-	action := probe.HTTPGet
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d%s", action.Port, action.Path), nil)
+func TCPSocketCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, error) {
+	action := probe.TCPSocket
+	address := fmt.Sprintf("localhost:%d", action.Port)
+	_, err := net.Dial("tcp", address)
 	if err != nil {
-		// fmt.Println(err.Error())
 		return false, nil
 	}
-	req.Close = true
-
-	for _, header := range action.HTTPHeaders {
-		req.Header.Set(header.Name, header.Value)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		// fmt.Println(err.Error())
-		return false, nil
-	}
-	for _, header := range action.ResponseHTTPHeaders {
-		if val, ok := resp.Header[header.Name]; ok {
-			if header.Value != strings.Join(val[:], "") {
-				return false, nil
-			}
-		}
-	}
-	defer resp.Body.Close()
 	return true, nil
 }

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -123,7 +123,7 @@ func executeCheck(method probeCallable, c container.ContainerInterface, probe *c
 			fails += 1
 			passes = 0
 		}
-		if passes > probe.SuccessThreshold || fails > probe.FailureThreshold {
+		if passes >= probe.SuccessThreshold || fails >= probe.FailureThreshold {
 			return passFail, err
 		}
 		if time.Since(start) > time.Duration(probe.TimeoutSeconds)*time.Second {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -93,6 +93,8 @@ func runCheck(results chan<- checkResult, c container.ContainerInterface, check 
 		p, err = executeCheck(ExecCheck, c, &check.Probe)
 	} else if check.Probe.HTTPGet != nil {
 		p, err = executeCheck(HTTPGetCheck, c, &check.Probe)
+	} else if check.Probe.TCPSocket != nil {
+		p, err = executeCheck(TCPSocketCheck, c, &check.Probe)
 	} else {
 		results <- checkResult{false, fmt.Errorf("check '%s' has no known probes", check.Name)}
 		return
@@ -121,7 +123,7 @@ func executeCheck(method probeCallable, c container.ContainerInterface, probe *c
 			fails += 1
 			passes = 0
 		}
-		if passes >= probe.SuccessThreshold || fails >= probe.FailureThreshold {
+		if passes > probe.SuccessThreshold || fails > probe.FailureThreshold {
 			return passFail, err
 		}
 		if time.Since(start) > time.Duration(probe.TimeoutSeconds)*time.Second {


### PR DESCRIPTION
- Added TCP probe
- Added Dask Scheduler manifest to test TCP
- Fixed default values not being set for the timeouts etc from #17 

Signed-off-by: Jacob Tomlinson <jtomlinson@nvidia.com>