### PR TITLE
Stop using external Docker images during testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,4 +12,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v3
-      - run: make test
+      - run: |
+          make testprep
+          make test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,17 @@ go build -o bin/canary .
 
 ### Testing
 
-You can invoke tests with:
+Tests require some example containers to use. Before you run the tests you must build them.
+
+```console
+$ make testprep
+docker build -t container-canary/kubeflow:shouldpass -f internal/testdata/containers/kubeflow.Dockerfile .
+[+] Building 1.7s (10/10) FINISHED
+...
+ => => naming to docker.io/container-canary/kubeflow:shouldpass
+ ```
+
+You can then invoke tests with:
 
 ```shell
 $ make test

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ package: ## Build for all platforms
 test: ## Run tests
 	go test -v ./...
 
+testprep: ## Run test prerequisite tasks
+	docker build -t container-canary/kubeflow:shouldpass -f internal/testdata/containers/kubeflow.Dockerfile .
+
 version:
 	@echo version: $(VERSION)
 

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -30,15 +30,15 @@ func TestValidate(t *testing.T) {
 	b := new(bytes.Buffer)
 	rootCmd.SetOut(b)
 	rootCmd.SetErr(b)
-	rootCmd.SetArgs([]string{"validate", "--file", "../examples/kubeflow.yaml", "daskdev/dask-notebook:latest"})
+	rootCmd.SetArgs([]string{"validate", "--file", "../examples/kubeflow.yaml", "container-canary/kubeflow:shouldpass"})
 	rootCmd.Execute()
 
-	assert.Contains(b.String(), "Validating daskdev/dask-notebook:latest against kubeflow", "did not validate")
+	assert.Contains(b.String(), "Validating container-canary/kubeflow:shouldpass against kubeflow", "did not validate")
 }
 
 func TestFileDoesNotExist(t *testing.T) {
 	assert := assert.New(t)
-	rootCmd.SetArgs([]string{"validate", "--file", "foo.yaml", "nginx"})
+	rootCmd.SetArgs([]string{"validate", "--file", "foo.yaml", "container-canary/kubeflow:shouldpass"})
 	err := rootCmd.Execute()
 	assert.NotNil(err, "did not error")
 }

--- a/internal/testdata/containers/kubeflow.Dockerfile
+++ b/internal/testdata/containers/kubeflow.Dockerfile
@@ -1,0 +1,16 @@
+FROM python
+
+ARG UNAME=jovyan
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+
+USER jovyan
+WORKDIR /home/jovyan
+
+ENV PATH=/home/jovyan/.local/bin:$PATH
+
+RUN pip install jupyterlab
+
+CMD jupyter lab


### PR DESCRIPTION
So far we've used external Docker images in testing, but this isn't ideal.

This PR adds a new `make testprep` command that will build some containers for use during testing.