### PR TITLE
Reinstate stdout assertions and add more tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test: ## Run tests
 
 testprep: ## Run test prerequisite tasks
 	docker build -t container-canary/kubeflow:shouldpass -f internal/testdata/containers/kubeflow.Dockerfile .
+	docker build -t container-canary/kubeflow:shouldfail -f internal/testdata/containers/kubeflow_broken.Dockerfile .
 
 version:
 	@echo version: $(VERSION)

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,12 +7,12 @@ For example the Kubeflow example from the README can be used directly like this.
 ```console
 $ canary validate --file https://raw.githubusercontent.com/NVIDIA/container-canary/main/examples/kubeflow.yaml public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.5.0-rc.1
 Validating public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:v1.5.0-rc.1 against kubeflow
- 👩 User is jovyan                                   [true]
- 🆔 User ID is 1000                                  [true]
- 🏠 Home directory is /home/jovyan                   [true]
- 🌏 Exposes an HTTP interface on port 8888           [true]
- 🧭 Correctly routes the NB_PREFIX                   [true]
- 🔓 Sets 'Access-Control-Allow-Origin: *' header     [true]
+ 🏠 Home directory is /home/jovyan                   [passed]
+ 👩 User is jovyan                                   [passed]
+ 🆔 User ID is 1000                                  [passed]
+ 🌏 Exposes an HTTP interface on port 8888           [passed]
+ 🔓 Sets 'Access-Control-Allow-Origin: *' header     [passed]
+ 🧭 Correctly routes the NB_PREFIX                   [passed]
 validation passed
 ```
 

--- a/internal/testdata/containers/kubeflow_broken.Dockerfile
+++ b/internal/testdata/containers/kubeflow_broken.Dockerfile
@@ -1,0 +1,19 @@
+FROM python
+
+ARG UNAME=bob
+ARG UID=1000
+ARG GID=1000
+RUN groupadd -g $GID -o $UNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $UNAME
+
+# Oh no this should be jovyan!
+USER bob
+
+# This should be /home/jovyan
+WORKDIR /home/bob
+
+ENV PATH=/home/bob/.local/bin:$PATH
+
+RUN pip install jupyterlab
+
+CMD jupyter lab --ip=0.0.0.0

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -225,7 +225,7 @@ func Validate(image string, configPath string, cmd *cobra.Command, debug bool) (
 	if err != nil {
 		tty = bufio.NewReader(os.Stdin)
 	}
-	p := tea.NewProgram(m, tea.WithInput(tty))
+	p := tea.NewProgram(m, tea.WithInput(tty), tea.WithOutput(cmd.OutOrStderr()))
 	out, err := p.StartReturningModel()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
- Ensure Bubble Tea stdout uses Cobra stdout to allow better mocking.
- Reinstate stdout assertions that were removed in #21. 
- Added a broken Kubeflow container example.
- Added a test to check the broken container fails.
- Updated the example doc with new stdout.