### PR TITLE
Improve handling of missing docker in tests

### DIFF
--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -53,6 +53,9 @@ func (c *DockerContainer) Start() error {
 	}
 
 	_, err := exec.Command("docker", commandArgs...).Output()
+	if err != nil && strings.Contains(err.Error(), "executable file not found ") {
+		return errors.New("unable to find 'docker' on the PATH, please ensure Docker is installed and running (you can check this by running 'docker info')")
+	}
 	c.runCommand = fmt.Sprintf("docker %s", strings.Join(commandArgs, " "))
 
 	for startTime := time.Now(); ; {

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -43,20 +43,24 @@ func TestDockerContainer(t *testing.T) {
 	defer c.Remove()
 	if err != nil {
 		t.Errorf("Failed to start container: %s", err.Error())
+		return
 	}
 
 	status, err := c.Status()
 	if err != nil {
 		t.Errorf("Failed to inspect container: %s", err.Error())
+		return
 	}
 	assert.Contains(status.RunCommand, "docker run", "Run command not stored correctly")
 
 	uname, err := c.Exec("uname", "-a")
 	if err != nil {
 		t.Errorf("Failed to exec command in container: %s", err.Error())
+		return
 	}
 	if !strings.Contains(uname, "Linux") {
 		t.Error("Output for command 'uname' did not contain expected string 'Linux'")
+		return
 	}
 }
 func TestDockerContainerRemoves(t *testing.T) {
@@ -65,10 +69,12 @@ func TestDockerContainerRemoves(t *testing.T) {
 	err := c.Start()
 	if err != nil {
 		t.Errorf("Failed to start container: %s", err.Error())
+		return
 	}
 
 	err = c.Remove()
 	if err != nil {
 		t.Errorf("Failed to remove container: %s", err.Error())
+		return
 	}
 }


### PR DESCRIPTION
Closes #31.

Adds a more useful error if Canary can't find the `docker` command on the PATH. Also, fast-failed tests if it is missing to avoid misleading segfaults being printed.