### PR TITLE
Add linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+name: Lint
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.41.1
+  hooks:
+    - id: golangci-lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,16 @@ go test -v ./...
 PASS
 ```
 
+## Linting
+
+This project enforces linting with `golangci-lint`. You can use [pre-commit](https://pre-commit.com/) to check this automatically on commit, which will save time as you can catch linting errors before the CI does.
+
+```console
+$ pre-commit install                                                                  
+pre-commit installed at .git/hooks/pre-commit
+
+$ pre-commit run --all-files
+
 ## Signing Your Work
 
 * We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -30,7 +30,8 @@ func TestRoot(t *testing.T) {
 	b := new(bytes.Buffer)
 	rootCmd.SetOut(b)
 	rootCmd.SetErr(b)
-	rootCmd.Execute()
+	err := rootCmd.Execute()
+	assert.Nil(err)
 
 	assert.Contains(b.String(), "Usage:", "did not how usage")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,10 +19,11 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/nvidia/container-canary/internal"
 	"github.com/spf13/cobra"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var versionCmd = &cobra.Command{
@@ -40,7 +41,7 @@ var versionCmd = &cobra.Command{
 }
 
 func showLine(cmd *cobra.Command, title string, value string) {
-	cmd.Printf(" %-16s %s\n", fmt.Sprintf("%s:", strings.Title(title)), value)
+	cmd.Printf(" %-16s %s\n", fmt.Sprintf("%s:", cases.Title(language.Und, cases.NoLower).String(title)), value)
 }
 
 func init() {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -31,7 +31,8 @@ func TestVersion(t *testing.T) {
 	rootCmd.SetOut(b)
 	rootCmd.SetErr(b)
 	rootCmd.SetArgs([]string{"version"})
-	rootCmd.Execute()
+	err := rootCmd.Execute()
+	assert.Nil(err)
 
 	assert.Contains(b.String(), "Version:", "mission version")
 	assert.Contains(b.String(), "Go Version:", "missing go version")

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -40,7 +40,12 @@ func TestDockerContainer(t *testing.T) {
 	c := New("nginx", env, ports, volumes, nil)
 
 	err := c.Start()
-	defer c.Remove()
+
+	defer func() {
+		err := c.Remove()
+		assert.Nil(err)
+	}()
+
 	if err != nil {
 		t.Errorf("Failed to start container: %s", err.Error())
 		return


### PR DESCRIPTION
- Add `golangci-lint` via `pre-commit`
- Update CI to run linting
- Document linting
- Couple of fixes to get linter to pass