### PR TITLE
Add error checking to container cleanup

### DIFF
--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -64,14 +64,20 @@ func (c *DockerContainer) Start() error {
 			return err
 		}
 		if info.State.Status == "exited" {
-			c.Remove()
+			err := c.Remove()
+			if err != nil {
+				return err
+			}
 			return errors.New("container failed to start")
 		}
 		if info.State.Running {
 			break
 		}
 		if time.Since(startTime) > (time.Second * 10) {
-			c.Remove()
+			err := c.Remove()
+			if err != nil {
+				return err
+			}
 			return errors.New("container failed to start after 10 seconds")
 		}
 		time.Sleep(time.Second)


### PR DESCRIPTION
Follow up to #35. 

In #36 we added linting but #35 failed the linter. Fixing things up in this PR to get `main` back to green.