### PR TITLE
Replace hub CLI with gh CLI

### DIFF
--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -31,4 +31,4 @@ jobs:
         run: |
           cd bin
           tag_name="${GITHUB_REF##*/}"
-          hub release edit $(find . -type f -name "canary_*" -printf "-a %p ") -m "" "$tag_name"
+          gh release upload "$tag_name" canary_*


### PR DESCRIPTION
The [`v0.3.0` release failed to publish assets](https://github.com/NVIDIA/container-canary/actions/runs/8005671433) because the `hub` CLI command was removed from GitHub Actions runners in October. See https://github.com/actions/runner-images/issues/8362.

This PR updates the script to use the `gh` CLI instead.

I've manually built and pushed the assets using the `gh` CLI for `v0.3.0` to test that they work, which they do. So this PR will come into effect for `v0.3.1` or above.