### PR TITLE
Fix unmarshalling of config file

### DIFF
--- a/examples/kubeflow.yaml
+++ b/examples/kubeflow.yaml
@@ -56,6 +56,9 @@ checks:
       httpGet:
         path: /
         port: 8888
+        httpHeaders:
+          - name: User-Agent
+            value: container-canary/0.2.1
         responseHttpHeaders:
           - name: Access-Control-Allow-Origin
             value: "*"

--- a/internal/apis/v1/types.go
+++ b/internal/apis/v1/types.go
@@ -104,26 +104,26 @@ func (p *Probe) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type HTTPGetAction struct {
 	// Path to access on the HTTP server.
 	// +optional
-	Path string `json:"path,omitempty"`
+	Path string `yaml:"path,omitempty"`
 	// Number of the port to access on the container.
 	// Number must be in the range 1 to 65535.
-	Port int `json:"port"`
+	Port int `yaml:"port"`
 	// Scheme to use for connecting to the host.
 	// Defaults to HTTP.
 	// +optional
-	Scheme v1.URIScheme `json:"scheme,omitempty"`
+	Scheme v1.URIScheme `yaml:"scheme,omitempty"`
 	// Custom headers to set in the request. HTTP allows repeated headers.
 	// +optional
-	HTTPHeaders []v1.HTTPHeader `json:"httpHeaders,omitempty"`
+	HTTPHeaders []v1.HTTPHeader `yaml:"httpHeaders,omitempty"`
 	// Headers expected in the response. Check will fail if any are missing.
 	// +optional
-	ResponseHTTPHeaders []v1.HTTPHeader `json:"responseHttpHeaders,omitempty"`
+	ResponseHTTPHeaders []v1.HTTPHeader `yaml:"responseHttpHeaders,omitempty"`
 }
 
 type TCPSocketAction struct {
 	// Number or name of the port to access on the container.
 	// Number must be in the range 1 to 65535.
-	Port int `json:"port"`
+	Port int `yaml:"port"`
 }
 
 type Volume struct {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -41,4 +41,19 @@ func TestValidator(t *testing.T) {
 
 	assert.Equal(0, check.Probe.InitialDelaySeconds)
 
+	check = validator.Checks[5]
+
+	assert.Equal("allow-origin-all", check.Name)
+	assert.Equal("🔓 Sets 'Access-Control-Allow-Origin: *' header", check.Description)
+
+	assert.Equal("/", check.Probe.HTTPGet.Path)
+	assert.Equal(8888, check.Probe.HTTPGet.Port)
+
+	header := check.Probe.HTTPGet.HTTPHeaders[0]
+	assert.Equal("User-Agent", header.Name)
+	assert.Equal("container-canary/0.2.1", header.Value)
+
+	header = check.Probe.HTTPGet.ResponseHTTPHeaders[0]
+	assert.Equal("Access-Control-Allow-Origin", header.Name)
+	assert.Equal("*", header.Value)
 }


### PR DESCRIPTION
Use `yaml` instead of `json` for fields to make sure YAML uses the right field name.