### PR TITLE
add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NVIDIA/container-canary-codeowners


### PR DESCRIPTION
Proposes adding a `CODEOWNERS` file so members of https://github.com/orgs/NVIDIA/teams/container-canary-codeowners will automatically be added as reviewers on PRs.

### Notes for Reviewers

CODEOWNERS docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners