### PR TITLE
fix formatting in CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@ $ pre-commit install
 pre-commit installed at .git/hooks/pre-commit
 
 $ pre-commit run --all-files
+```
 
 ## Signing Your Work
 


### PR DESCRIPTION
Fixes a markdown formatting issue in `CONTRIBUTING.md`.

**Before:**

<img width="990" alt="image" src="https://github.com/user-attachments/assets/2c5094a0-0c1c-4296-869b-0a4ea5e8e2c6">

ref: https://github.com/NVIDIA/container-canary/blob/main/CONTRIBUTING.md

**After:**

<img width="972" alt="image" src="https://github.com/user-attachments/assets/fd644b5c-2a7b-41ff-9c34-f39c4dbd2651">

ref: https://github.com/jameslamb/container-canary/blob/docs/formatting/CONTRIBUTING.md
