### PR TITLE
upgrade golangci-lint, run pre-commit in CI, add more pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,13 +4,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
 
-      - name: Checkout source
-        uses: actions/checkout@v4
+      # - name: Install Python
+      #   uses: actions/setup-python@v3
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,8 +12,5 @@ jobs:
         with:
           go-version: 1.21.x
 
-      # - name: Install Python
-      #   uses: actions/setup-python@v3
-
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,11 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.41.1
+  rev: v1.59.1
   hooks:
     - id: golangci-lint
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ PASS
 This project enforces linting with `golangci-lint`. You can use [pre-commit](https://pre-commit.com/) to check this automatically on commit, which will save time as you can catch linting errors before the CI does.
 
 ```console
-$ pre-commit install                                                                  
+$ pre-commit install
 pre-commit installed at .git/hooks/pre-commit
 
 $ pre-commit run --all-files


### PR DESCRIPTION
On #65, I observed linting failing in CI even though `pre-commit run --all-files` passed for me locally.

Looks like that was because `pre-commit` isn't run in CI here. Instead, this third-party action is used:

https://github.com/NVIDIA/container-canary/blob/8f14a3e309788e5a1eb0901cf1559bf7bcfaf56f/.github/workflows/lint.yaml#L15-L16

This proposes the following:

* update to the latest version of `golangci-lint` in pre-commit config
* add a few more small pre-commit hooks (for trailing whitespace and newlines)
* run `pre-commit` in CI