### PR TITLE
avoid unnecessary build context in 'make testprep'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ test: ## Run tests
 	go test -v ./...
 
 testprep: ## Run test prerequisite tasks
-	docker build -t container-canary/kubeflow:shouldpass -f internal/testdata/containers/kubeflow.Dockerfile .
-	docker build -t container-canary/kubeflow:shouldfail -f internal/testdata/containers/kubeflow_broken.Dockerfile .
+	docker build -t container-canary/kubeflow:shouldpass - < internal/testdata/containers/kubeflow.Dockerfile
+	docker build -t container-canary/kubeflow:shouldfail - < internal/testdata/containers/kubeflow_broken.Dockerfile
 
 version:
 	@echo version: $(VERSION)


### PR DESCRIPTION
`make testprep` builds some docker images to be used in this project's tests.

Those images don't need any local files (i.e. their Dockefiles don't contain `COPY` or `ADD` statements), so passing in the build context like `docker build -f Dockerfile .` is unnecessary.

This proposes instead switching them to no-context builds. That makes the builds slightly faster and their intention a bit clearer.

## Notes for Reviewers

### How I tested this

Ran the following.

```shell
make clean testprep
```

On `main`:

```text
Sending build context to Docker daemon  770.6kB
```

On this branch:

```text
Sending build context to Docker daemon  2.048kB
```

That's not a huge difference, but this change would protect against other files accidentally left lying around in the repo from also being added to that build context unnecessarily.
