### PR TITLE
fix: Example: Vertex AI Workbench

### DIFF
--- a/examples/vertex-ai-workbench.yaml
+++ b/examples/vertex-ai-workbench.yaml
@@ -1,0 +1,35 @@
+apiVersion: container-canary.nvidia.com/v1
+kind: Validator
+name: vertex-ai-workbench
+description: Vertex AI Workbench
+documentation: https://cloud.google.com/vertex-ai/docs/workbench/instances/create-custom-container
+env: []
+ports:
+  - port: 8080
+    protocol: TCP
+volumes:
+  - mountPath: /home/jupyter
+checks:
+  - name: user
+    description: 👩 User is jupyter
+    probe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - "[ $(whoami) = jupyter ]"
+  - name: home
+    description: 🏠 Home directory is /home/jupyter
+    probe:
+      exec:
+        command:
+          - /bin/sh
+          - -c
+          - "[ $HOME = /home/jupyter ]"
+  - name: http
+    description: 🌏 Exposes an HTTP interface on port 8080
+    probe:
+      httpGet:
+        path: /
+        port: 8080
+      failureThreshold: 30


### PR DESCRIPTION
## Summary

## Root Cause

Issue #39 requests a new example validator YAML for Vertex AI Workbench. No such file existed in the `examples/` directory. The issue links to Google Cloud's documentation for custom containers used with Vertex AI Workbench.

## Change Made

Created `examples/vertex-ai-workbench.yaml` — a validator manifest for Vertex AI Workbench custom containers.

Key requirements sourced from https://cloud.google.com/vertex-ai/docs/workbench/instances/create-custom-container:

- **Port 8080**: JupyterLab must be configured to listen on port 8080 (not 8888 like Kubeflow). The proxy agent forwards requests to port 8080.
- **User `jupyter`**: The default user in Vertex AI Workbench containers is `jupyter` (not `jovyan`).
- **Home directory `/home/jupyter`**: The persistent data disk is mounted at `/home/jupyter`.

The validator checks:
1. That the container user is `jupyter`
2. That `$HOME` is `/home/jupyter`
3. That an HTTP interface is accessible on port 8080



## Issue

Fixes #39

**Issue URL:** https://github.com/NVIDIA/container-canary/issues/39


## Changes

```
examples/vertex-ai-workbench.yaml | 35 +++++++++++++++++++++++++++++++++++
 1 file changed, 35 insertions(+)
```


## Testing


- Agent ran relevant tests during development

- Linting checks passed

- Changes are minimal and focused on the issue


## AI Assistance Disclosure


This pull request was prepared with the assistance of AI coding tools (GitHub Copilot). The change has been read, understood, and is owned by the human contributor submitting it, who will respond to review feedback.
