### PR TITLE
Fix HTTP response validation

### DIFF
--- a/examples/kubeflow.yaml
+++ b/examples/kubeflow.yaml
@@ -40,7 +40,7 @@ checks:
     description: 🌏 Exposes an HTTP interface on port 8888
     probe:
       httpGet:
-        path: /
+        path: /hub/jovyan/lab
         port: 8888
       failureThreshold: 30
   - name: NB_PREFIX
@@ -54,7 +54,7 @@ checks:
     description: "🔓 Sets 'Access-Control-Allow-Origin: *' header"
     probe:
       httpGet:
-        path: /
+        path: /hub/jovyan/lab
         port: 8888
         httpHeaders:
           - name: User-Agent

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -46,7 +46,7 @@ func TestValidator(t *testing.T) {
 	assert.Equal("allow-origin-all", check.Name)
 	assert.Equal("🔓 Sets 'Access-Control-Allow-Origin: *' header", check.Description)
 
-	assert.Equal("/", check.Probe.HTTPGet.Path)
+	assert.Equal("/hub/jovyan/lab", check.Probe.HTTPGet.Path)
 	assert.Equal(8888, check.Probe.HTTPGet.Port)
 
 	header := check.Probe.HTTPGet.HTTPHeaders[0]

--- a/internal/testdata/containers/kubeflow.Dockerfile
+++ b/internal/testdata/containers/kubeflow.Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.14
 
 ARG UNAME=jovyan
 ARG UID=1000
@@ -11,6 +11,6 @@ WORKDIR /home/jovyan
 
 ENV PATH=/home/jovyan/.local/bin:$PATH
 
-RUN pip install jupyterlab
+RUN pip install jupyterlab==4.6.1 jupyter-server==2.20.0
 
-CMD jupyter lab --ip=0.0.0.0
+CMD jupyter lab --ip=0.0.0.0 --ServerApp.base_url="${NB_PREFIX}" --ServerApp.allow_origin="*" --IdentityProvider.token=""

--- a/internal/testdata/containers/kubeflow_broken.Dockerfile
+++ b/internal/testdata/containers/kubeflow_broken.Dockerfile
@@ -1,4 +1,4 @@
-FROM python
+FROM python:3.14
 
 ARG UNAME=bob
 ARG UID=1000
@@ -14,6 +14,6 @@ WORKDIR /home/bob
 
 ENV PATH=/home/bob/.local/bin:$PATH
 
-RUN pip install jupyterlab
+RUN pip install jupyterlab==4.6.1 jupyter-server==2.20.0
 
-CMD jupyter lab --ip=0.0.0.0
+CMD jupyter lab --ip=0.0.0.0 --ServerApp.base_url="${NB_PREFIX}" --ServerApp.allow_origin="*" --IdentityProvider.token=""

--- a/internal/validator/httpget.go
+++ b/internal/validator/httpget.go
@@ -28,6 +28,8 @@ import (
 
 func HTTPGetCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, error) {
 	action := probe.HTTPGet
+	// Match the Kubernetes kubelet: follow redirects and treat any 2xx or 3xx
+	// (200 <= code < 400) response as a success.
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d%s", action.Port, action.Path), nil)
 	if err != nil {
@@ -42,13 +44,16 @@ func HTTPGetCheck(c container.ContainerInterface, probe *canaryv1.Probe) (bool, 
 	if err != nil {
 		return false, nil
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return false, nil
+	}
 	for _, header := range action.ResponseHTTPHeaders {
-		if val, ok := resp.Header[header.Name]; ok {
-			if header.Value != strings.Join(val[:], "") {
-				return false, nil
-			}
+		val, ok := resp.Header[header.Name]
+		if !ok || header.Value != strings.Join(val[:], "") {
+			return false, nil
 		}
 	}
-	defer resp.Body.Close()
 	return true, nil
 }

--- a/internal/validator/httpget_test.go
+++ b/internal/validator/httpget_test.go
@@ -1,0 +1,127 @@
+/*
+* SPDX-FileCopyrightText: Copyright (c) <2026> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+* SPDX-License-Identifier: Apache-2.0
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package validator
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	canaryv1 "github.com/nvidia/container-canary/internal/apis/v1"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestHTTPGetCheckStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       bool
+	}{
+		{name: "200 passes", statusCode: http.StatusOK, want: true},
+		{name: "299 passes", statusCode: 299, want: true},
+		{name: "301 passes", statusCode: http.StatusMovedPermanently, want: true},
+		{name: "399 passes", statusCode: 399, want: true},
+		{name: "400 fails", statusCode: http.StatusBadRequest, want: false},
+		{name: "404 fails", statusCode: http.StatusNotFound, want: false},
+		{name: "503 fails", statusCode: http.StatusServiceUnavailable, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer server.Close()
+
+			got, err := HTTPGetCheck(nil, httpGetProbe(server, nil))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHTTPGetCheckFollowsRedirect(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       string
+		targetStatus int
+		want         bool
+	}{
+		{name: "redirect to success passes", target: "/healthy", targetStatus: http.StatusOK, want: true},
+		{name: "redirect to error fails", target: "/broken", targetStatus: http.StatusInternalServerError, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/" {
+					http.Redirect(w, r, tt.target, http.StatusFound)
+					return
+				}
+				w.WriteHeader(tt.targetStatus)
+			}))
+			defer server.Close()
+
+			got, err := HTTPGetCheck(nil, httpGetProbe(server, nil))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHTTPGetCheckResponseHeaders(t *testing.T) {
+	tests := []struct {
+		name          string
+		responseValue string
+		setHeader     bool
+		want          bool
+	}{
+		{name: "matching header passes", responseValue: "expected", setHeader: true, want: true},
+		{name: "wrong header value fails", responseValue: "unexpected", setHeader: true, want: false},
+		{name: "missing header fails", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.setHeader {
+					w.Header().Set("X-Canary-Test", tt.responseValue)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			headers := []v1.HTTPHeader{{Name: "X-Canary-Test", Value: "expected"}}
+			got, err := HTTPGetCheck(nil, httpGetProbe(server, headers))
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func httpGetProbe(server *httptest.Server, responseHeaders []v1.HTTPHeader) *canaryv1.Probe {
+	return &canaryv1.Probe{
+		HTTPGet: &canaryv1.HTTPGetAction{
+			Path:                "/",
+			Port:                server.Listener.Addr().(*net.TCPAddr).Port,
+			ResponseHTTPHeaders: responseHeaders,
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- reject final HTTP responses with status codes of 400 or higher while retaining redirect-following behavior
- require every configured response header to be present and match its expected value
- close response bodies on all validation exits
- add focused status, redirect, and response-header tests
- pin and configure the JupyterLab integration fixtures to serve the configured `NB_PREFIX` route with the expected CORS header

The missing-response-header behavior is an intentional additional correction: configured headers that are absent now fail validation instead of silently passing.

## Testing

- `make testprep`
- `go test ./cmd`
- `go test ./internal/validator/...`
- `go vet ./...`

Closes #80