### PR TITLE
fix: version header bypasses command output stream

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -29,7 +29,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version of containercanary",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Container Canary")
+		cmd.Println("Container Canary")
 		showLine(cmd, "Version", internal.Version)
 		showLine(cmd, "Go Version", internal.GoVersion)
 		showLine(cmd, "Commit", internal.Commit)


### PR DESCRIPTION
This PR addresses the following issue in `cmd/version.go`: version header bypasses command output stream.

## Changes
- `cmd/version.go`: version header bypasses command output stream.

## Details
```diff
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,1 +1,1 @@
-		fmt.Println("Container Canary")
+		cmd.Println("Container Canary")
```

## Tests
- `cmd/version_test.go`

```diff
--- /dev/null
+++ cmd/version_test.go
@@ -0,0 +0,0 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionRespectsOutputStream(t *testing.T) {
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{"version"})
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("version command failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "Container Canary") {
+		t.Errorf("expected header 'Container Canary' in redirected output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Version:") {
+		t.Errorf("expected 'Version:' line in redirected output, got:\n%s", out)
+	}
+}
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).